### PR TITLE
Misc Updates:

### DIFF
--- a/src/AlignmentVault.sol
+++ b/src/AlignmentVault.sol
@@ -123,6 +123,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
         IERC721(alignedNft_).setApprovalForAll(address(_NFTX_POSITION_ROUTER), true);
         IERC721(alignedNft_).setApprovalForAll(address(_NFTX_LIQUIDITY), true);
         IERC721(alignedNft_).setApprovalForAll(vault, true);
+        IERC721(address(_NFTX_POSITION_ROUTER.positionManager())).setApprovalForAll(address(_NFTX_POSITION_ROUTER), true);
 
         IERC20(vault).approve(address(_NFTX_INVENTORY), type(uint256).max);
         IERC20(vault).approve(address(_NFTX_POSITION_ROUTER), type(uint256).max);

--- a/src/IAlignmentVault.sol
+++ b/src/IAlignmentVault.sol
@@ -158,25 +158,25 @@ interface IAlignmentVault {
         uint24 fee,
         uint256 amountOutMinimum,
         uint160 sqrtPriceLimitX96
-    ) external payable;
+    ) external payable returns (uint256 vTokenBought);
     function buyVTokenExact(
         uint256 ethAmount,
         uint24 fee,
         uint256 amountOutExact,
         uint160 sqrtPriceLimitX96
-    ) external payable;
+    ) external payable returns (uint256 ethSpent);
     function sellVToken(
         uint256 vTokenAmount,
         uint24 fee,
         uint256 amountOutMinimum,
         uint160 sqrtPriceLimitX96
-    ) external payable;
+    ) external payable returns (uint256 ethBought);
     function sellVTokenExact(
         uint256 vTokenAmount,
         uint24 fee,
         uint256 amountOutExact,
         uint160 sqrtPriceLimitX96
-    ) external payable;
+    ) external payable returns (uint256 vTokenSpent);
 
     // >>>>>>>>>>>> [ MISCELLANEOUS TOKEN MANAGEMENT ] <<<<<<<<<<<<
 

--- a/src/IAlignmentVault.sol
+++ b/src/IAlignmentVault.sol
@@ -15,6 +15,10 @@ interface IAlignmentVault {
 
     error AV_UnalignedNft();
     error AV_ProhibitedWithdrawal();
+    error AV_MismatchedArrayLength();
+    error AV_PositionAlreadySet();
+    error AV_NotPositionOwner();
+    error AV_InsufficientSharesToWithdrawNft();
 
     // >>>>>>>>>>>> [ INITIALIZER ERRORS ] <<<<<<<<<<<<
 
@@ -96,13 +100,14 @@ interface IAlignmentVault {
     function inventoryPositionIncrease(uint256 positionId, uint256 vTokenAmount) external payable;
     function inventoryPositionWithdrawal(
         uint256 positionId_,
-        uint256 vTokenAmount,
+        uint256 vTokenShares,
         uint256[] calldata tokenIds,
         uint256 vTokenPremiumLimit
     ) external payable;
     function inventoryPositionCombine(uint256 positionId, uint256[] calldata childPositionIds) external payable;
     function inventoryPositionCollectFees(address recipient, uint256[] calldata positionIds) external payable;
     function inventoryPositionCollectAllFees(address recipient) external payable;
+    function inventoryPositionUpdateSet(uint256 positionId) external payable;
 
     // >>>>>>>>>>>> [ LIQUIDITY POSITION MANAGEMENT ] <<<<<<<<<<<<
 
@@ -136,6 +141,7 @@ interface IAlignmentVault {
     ) external payable;
     function liquidityPositionCollectFees(address recipient, uint256[] calldata positionIds) external payable;
     function liquidityPositionCollectAllFees(address recipient) external payable;
+    function liquidityPositionUpdateSet(uint256 positionId) external payable;
 
     // >>>>>>>>>>>> [ ALIGNED TOKEN MANAGEMENT ] <<<<<<<<<<<<
 
@@ -176,13 +182,6 @@ interface IAlignmentVault {
 
     function rescueERC20(address token, uint256 amount, address recipient) external payable;
     function rescueERC721(address token, uint256 tokenId, address recipient) external payable;
-    function rescueERC1155(address token, uint256 tokenId, uint256 amount, address recipient) external payable;
-    function rescueERC1155Batch(
-        address token,
-        uint256[] calldata tokenIds,
-        uint256[] calldata amounts,
-        address recipient
-    ) external payable;
     function wrapEth(uint256 amount) external payable;
     function unwrapEth(uint256 amount) external payable;
 }

--- a/src/testnet/AlignmentVault.sol
+++ b/src/testnet/AlignmentVault.sol
@@ -744,4 +744,11 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
 
     receive() external payable virtual {}
     fallback() external payable virtual {}
+
+    // >>>>>>>>>>>> [ TEMP  ] <<<<<<<<<<<<
+    // implementing to compile
+    
+    function inventoryPositionUpdateSet(uint256 positionId) external payable {}
+    function liquidityPositionUpdateSet(uint256 positionId) external payable {}
+
 }

--- a/src/testnet/AlignmentVault.sol
+++ b/src/testnet/AlignmentVault.sol
@@ -581,7 +581,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
         uint24 fee,
         uint256 amountOutMinimum,
         uint160 sqrtPriceLimitX96
-    ) external payable onlyOwner {
+    ) external payable onlyOwner returns (uint256 val) {
         uint256 wethBalance = _WETH.balanceOf(address(this));
         if (ethAmount > wethBalance) _WETH.deposit{value: ethAmount - wethBalance}();
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
@@ -594,7 +594,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
             amountOutMinimum: amountOutMinimum,
             sqrtPriceLimitX96: sqrtPriceLimitX96
         });
-        _NFTX_SWAP_ROUTER.exactInputSingle(params);
+        val = _NFTX_SWAP_ROUTER.exactInputSingle(params);
         _WETH.withdraw(_WETH.balanceOf(address(this)));
     }
 
@@ -603,7 +603,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
         uint24 fee,
         uint256 amountOutExact,
         uint160 sqrtPriceLimitX96
-    ) external payable onlyOwner {
+    ) external payable onlyOwner returns (uint256 val) {
         uint256 wethBalance = _WETH.balanceOf(address(this));
         if (ethAmount > wethBalance) _WETH.deposit{value: ethAmount - wethBalance}();
         ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter.ExactOutputSingleParams({
@@ -616,7 +616,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
             amountInMaximum: ethAmount,
             sqrtPriceLimitX96: sqrtPriceLimitX96
         });
-        _NFTX_SWAP_ROUTER.exactOutputSingle(params);
+        val = _NFTX_SWAP_ROUTER.exactOutputSingle(params);
         _WETH.withdraw(_WETH.balanceOf(address(this)));
     }
 
@@ -625,7 +625,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
         uint24 fee,
         uint256 amountOutMinimum,
         uint160 sqrtPriceLimitX96
-    ) external payable onlyOwner {
+    ) external payable onlyOwner returns (uint256 val) {
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: vault,
             tokenOut: address(_WETH),
@@ -636,7 +636,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
             amountOutMinimum: amountOutMinimum,
             sqrtPriceLimitX96: sqrtPriceLimitX96
         });
-        _NFTX_SWAP_ROUTER.exactInputSingle(params);
+        val = _NFTX_SWAP_ROUTER.exactInputSingle(params);
         _WETH.withdraw(_WETH.balanceOf(address(this)));
     }
 
@@ -645,7 +645,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
         uint24 fee,
         uint256 amountOutExact,
         uint160 sqrtPriceLimitX96
-    ) external payable onlyOwner {
+    ) external payable onlyOwner returns (uint256 val) {
         ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter.ExactOutputSingleParams({
             tokenIn: vault,
             tokenOut: address(_WETH),
@@ -656,7 +656,7 @@ contract AlignmentVault is Ownable, Initializable, ERC721Holder, ERC1155Holder, 
             amountInMaximum: vTokenAmount,
             sqrtPriceLimitX96: sqrtPriceLimitX96
         });
-        _NFTX_SWAP_ROUTER.exactOutputSingle(params);
+        val = _NFTX_SWAP_ROUTER.exactOutputSingle(params);
         _WETH.withdraw(_WETH.balanceOf(address(this)));
     }
 

--- a/test/AlignmentVault.t.sol
+++ b/test/AlignmentVault.t.sol
@@ -1,12 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.23;
 
-import "../lib/forge-std/src/Test.sol";
+// >>>>>>>>>>>> [ IMPORTS ] <<<<<<<<<<<<
+
+// Contracts
 import {AlignmentVault} from "../src/AlignmentVault.sol";
-import {IAlignmentVault} from "../src/IAlignmentVault.sol";
 import {FixedPointMathLib} from "../lib/solady/src/utils/FixedPointMathLib.sol";
 import {AlignmentVaultFactory} from "./../src/AlignmentVaultFactory.sol";
 
+// Libraries
+import "../lib/forge-std/src/Test.sol";
+import {Position} from "../lib/nftx-protocol-v3/src/uniswap/v3-core/libraries/Position.sol";
+import {TickMath} from "../lib/nftx-protocol-v3/src/uniswap/v3-core/libraries/TickMath.sol";
+import {LiquidityAmounts} from "../lib/nftx-protocol-v3/src/uniswap/v3-periphery/libraries/LiquidityAmounts.sol";
+import {FullMath} from "../lib/nftx-protocol-v3/src/uniswap/v3-core/libraries/FullMath.sol";
+
+// Interfaces
+import {IAlignmentVault} from "../src/IAlignmentVault.sol";
 import {IWETH9} from "../lib/nftx-protocol-v3/src/uniswap/v3-periphery/interfaces/external/IWETH9.sol";
 import {IERC20} from "../lib/openzeppelin-contracts-v5/contracts/interfaces/IERC20.sol";
 import {IERC721} from "../lib/openzeppelin-contracts-v5/contracts/interfaces/IERC721.sol";
@@ -19,9 +29,11 @@ import {INonfungiblePositionManager} from
     "../lib/nftx-protocol-v3/src/uniswap/v3-periphery/interfaces/INonfungiblePositionManager.sol";
 import {INFTXRouter} from "../lib/nftx-protocol-v3/src/interfaces/INFTXRouter.sol";
 import {ISwapRouter} from "../lib/nftx-protocol-v3/src/uniswap/v3-periphery/interfaces/ISwapRouter.sol";
+import {IUniswapV3Pool} from "../lib/nftx-protocol-v3/src/uniswap/v3-core/interfaces/IUniswapV3Pool.sol";
+
 
 contract AlignmentVaultTest is Test {
-    uint256 private constant NFTX_STANDARD_FEE = 30_000_000_000_000_000;
+    uint256 public constant NFTX_STANDARD_FEE = 30_000_000_000_000_000;
     IWETH9 public constant WETH = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     //@audit  is upgradable
     //@audit pay attention to this integration
@@ -45,6 +57,10 @@ contract AlignmentVaultTest is Test {
     address public vault;
     uint256 public vaultId;
     address public alignedNft;
+    bytes32 public positionKey;
+    address public positionManager;
+    IUniswapV3Pool public pool;
+    
 
     uint256[] public none = new uint256[](0);
     uint24 public constant STANDARD_FEE = 3000;
@@ -55,6 +71,9 @@ contract AlignmentVaultTest is Test {
 
     address deployer;
     address attacker;
+
+    event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1);
+    event AV_LiquidityPositionCreated(uint256 indexed positionId);
 
     function setUp() public virtual {
         vm.createSelectFork("mainnet");
@@ -79,6 +98,8 @@ contract AlignmentVaultTest is Test {
         vault = av.vault();
         vaultId = VAULT_ID;
         alignedNft = MILADY;
+        positionManager = address(NFTX_POSITION_ROUTER.positionManager());
+        pool = _getPool();
 
         setApprovals();
     }
@@ -119,146 +140,6 @@ contract AlignmentVaultTest is Test {
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    //                  INIT LOGIC
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    function lazyInitialize(address alignedNft_) public {
-        vm.startPrank(deployer);
-        bytes32 salt = keccak256('deterministic salt');
-        av = AlignmentVault(payable(avf.predictDeterministicAddress(salt)));
-        alignedNft = alignedNft_;
-        address[] memory vaults = NFTX_VAULT_FACTORY.vaultsForAsset(alignedNft_);
-        if (vaults.length == 0) revert IAlignmentVault.AV_NFTX_NoVaultsExist();
-
-        for (uint256 i; i < vaults.length; ++i) {
-            (uint256 mintFee, uint256 redeemFee, uint256 swapFee) = INFTXVaultV3(vaults[i]).vaultFees();
-            if (mintFee != NFTX_STANDARD_FEE || redeemFee != NFTX_STANDARD_FEE || swapFee != NFTX_STANDARD_FEE) {
-                continue;
-            } else if (INFTXVaultV3(vaults[i]).manager() != address(0)) {
-                continue;
-            } else {
-                vaultId = INFTXVaultV3(vaults[i]).vaultId();
-                vault = vaults[i];
-                break;
-            }
-        }
-
-        vm.expectEmit(address(av));
-        emit IAlignmentVault.AV_VaultInitialized(vault, vaultId);
-        //@audit what does it mean when vault id is zero?
-        //@response The initializer just wants it pointed at a standard 3/3/3 tax and finalized NFTX vault, if any exist
-        avf.deployDeterministic(deployer, alignedNft_, 0, salt);
-        vm.deal(address(av), FUNDING_AMOUNT);
-        setApprovals();
-        vm.stopPrank();
-    }
-
-    function targetInitialize(address alignedNft_, uint96 vaultId_) public {
-        bytes32 salt = keccak256('deterministic salt');
-        av = AlignmentVault(payable(avf.predictDeterministicAddress(salt)));
-        vault = NFTX_VAULT_FACTORY.vault(vaultId_);
-        vaultId = vaultId_;
-        alignedNft = alignedNft_;
-
-        vm.expectEmit(address(av));
-        emit IAlignmentVault.AV_VaultInitialized(vault, vaultId_);
-        avf.deployDeterministic(deployer, alignedNft_, vaultId_, salt);
-        vm.deal(address(av), FUNDING_AMOUNT);
-        setApprovals();
-    }
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    //                  RECEIVE LOGIC
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    /*function testRescueERC20() public {
-        av.rescueERC20(address(0), 1, address(0));
-    }
-
-    function testRescueERC1155() public {
-        av.rescueERC1155(address(0), 1, 1, address(0));
-    }
-
-    function testRescueERC721() public {
-        av.rescueERC721(address(0), 1, address(0));
-    }*/
-
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    // //                  ALIGNED TOKEN MANAGEMENT
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    // function testBuyNftsFromPool() public {}
-    // function testMintVToken() public {}
-    // function testBuyVToken() public {}
-    // function testBuyVTokenExact() public {}
-    // function testSellVToken() public {}
-    // function testSellVTokenExact() public {}
-    // function testUnwrapEth() public {}
-
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    // //                  LIQUIDITY POSITION MANAGEMENT
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    // function testliquidityPositionCreatename() public {}
-    // function testliquidityPositionIncrease() public {}
-
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    // //                  INVENTORY POSITION MANAGEMENT
-    // /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    // function testInventoryPositionCreateVToken() public {}
-    // function testInventoryPositionCreateNfts() public {}
-    // function testInventoryPositionIncrease() public {}
-    // function testInventoryPositionWithdrawal() public {}
-    // function testInventoryPositionCombine() public {}
-    // function testInventoryPositionCollectFees() public {}
-    // function testInventoryPositionCollectAllFees() public {}
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    //                  VIEW FUNCTIONS
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    /*function testGetInventoryPositionIds() public view {
-        av.getInventoryPositionIds();
-    }
-
-    function testGetLiquidityPositionIds() public view {
-        av.getLiquidityPositionIds();
-    }
-
-    function testGetSpecificInventoryPositionFees(uint256 posId) public view {
-        av.getSpecificInventoryPositionFees(posId);
-    }
-
-    function testGetTotalInventoryPositionFees() public view {
-        av.getTotalInventoryPositionFees();
-    }
-
-    function testGetSpecificLiquidityPositionFees(uint256 id) public view {
-        av.getSpecificLiquidityPositionFees(id);
-    }
-
-    function testGetTotalLiquidityPositionFees() public view {
-        av.getTotalLiquidityPositionFees();
-    }*/
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    //                  INIT LOGIC TESTS
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-
-    function testTargetInitialize() public {
-        targetInitialize(MILADY, VAULT_ID);
-        assertEq(av.vaultId(), VAULT_ID);
-        assertEq(address(av.alignedNft()), MILADY);
-    }
-
-    function testLazyInitialize() public {
-        lazyInitialize(MILADY);
-        assertEq(av.vaultId(), VAULT_ID);
-        assertEq(address(av.alignedNft()), MILADY);
-    }
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
     //                   HELPER FUNCTIONS
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
 
@@ -266,5 +147,100 @@ contract AlignmentVaultTest is Test {
     function _changePrank(address who) internal {
         vm.stopPrank();
         vm.startPrank(who);
+    }
+
+    function _getPool() internal view returns (IUniswapV3Pool) {
+        (address poolAddress,,) = av.getUniswapPoolValues();
+
+        return IUniswapV3Pool(poolAddress);
+    }
+
+    function _getCurrentTick() internal view returns (int24 tick) {
+        (, tick,,,,,) = IUniswapV3Pool(pool).slot0();
+    }
+
+    function _getUpperLowerTicks() internal view returns (int24 tickUpper, int24 tickLower) {
+        int24 tick = _getCurrentTick();
+        int24 tick1 = tick + (tick / 10);
+        int24 tick2 = tick - (tick / 10);
+
+        tick1 = _conformTickSpacing(tick1);
+        tick2 = _conformTickSpacing(tick2);
+
+        (tickUpper, tickLower) = tick1 > tick2 ? (tick1, tick2) : (tick2, tick1);
+    }
+
+    function _conformTickSpacing(int24 tick) internal view returns (int24) {
+        int24 spacing = pool.tickSpacing();
+        return tick % spacing == 0 ? tick : tick - (tick % spacing);
+    }
+
+    function _getLiquidity(uint256 id) internal view returns (uint128 liquidity) {
+        (,,,,,,, liquidity,,,,) = INonfungiblePositionManager(positionManager).positions(id);
+    }
+
+    function _getPositionTicks(uint256 id) internal view returns (int24 tickLower, int24 tickUpper) {
+        (,,,,, tickLower, tickUpper,,,,,) = INonfungiblePositionManager(positionManager).positions(id);
+    }
+
+    function _buyVTokenFromPool(address trader, uint256 amount) internal {
+        deal(address(WETH), trader, amount);
+
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+            tokenIn: address(WETH),
+            tokenOut: vault,
+            fee: STANDARD_FEE,
+            recipient: trader,
+            deadline: block.timestamp,
+            amountIn: amount,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+
+        _changePrank(trader);
+        WETH.approve(address(NFTX_SWAP_ROUTER), amount);
+        NFTX_SWAP_ROUTER.exactInputSingle(params);
+    }
+
+    function _buyWethFromPool(address trader, uint256 amount) internal {
+        deal(vault, trader, amount);
+
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+            tokenIn: vault,
+            tokenOut: address(WETH),
+            fee: STANDARD_FEE,
+            recipient: trader,
+            deadline: block.timestamp,
+            amountIn: amount,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+
+        _changePrank(trader);
+        IERC20(vault).approve(address(NFTX_SWAP_ROUTER), amount);
+        NFTX_SWAP_ROUTER.exactInputSingle(params);
+    }
+
+    function _getLiquidityForAmounts(
+        uint256 ethAmount,
+        uint256 vTokenAmount,
+        int24 tickLower,
+        int24 tickUpper
+    ) internal view returns (uint128 liquidity) {
+        (uint160 sqrtPriceX96,,,,,,) = pool.slot0();
+        uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(tickLower);
+        uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(tickUpper);
+
+        (uint256 amount0, uint256 amount1) =
+            address(vault) < address(WETH) ? (vTokenAmount, ethAmount) : (ethAmount, vTokenAmount);
+
+        liquidity =
+            LiquidityAmounts.getLiquidityForAmounts(sqrtPriceX96, sqrtRatioAX96, sqrtRatioBX96, amount0, amount1);
+    }
+
+    /// @dev refreshes position to get updated fee growth
+    function _refreshPosition(int24 tickLower, int24 tickUpper) internal {
+        _changePrank(positionManager);
+        pool.burn(tickLower, tickUpper, 0);
     }
 }

--- a/test/AlignmentVault.t.sol
+++ b/test/AlignmentVault.t.sol
@@ -73,7 +73,6 @@ contract AlignmentVaultTest is Test {
     address attacker;
 
     event Collect(uint256 indexed tokenId, address recipient, uint256 amount0, uint256 amount1);
-    event AV_LiquidityPositionCreated(uint256 indexed positionId);
 
     function setUp() public virtual {
         vm.createSelectFork("mainnet");
@@ -236,6 +235,25 @@ contract AlignmentVaultTest is Test {
 
         liquidity =
             LiquidityAmounts.getLiquidityForAmounts(sqrtPriceX96, sqrtRatioAX96, sqrtRatioBX96, amount0, amount1);
+    }
+
+    function _getAmountsForLiquidity(
+        uint128 liquidity,
+        int24 tickLower,
+        int24 tickUpper
+    ) internal view returns (uint256 ethAmount, uint256 vTokenAmount) {
+        (uint160 sqrtPriceX96,,,,,,) = pool.slot0();
+        uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(tickLower);
+        uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(tickUpper);
+
+        (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96,
+            sqrtRatioAX96,
+            sqrtRatioBX96,
+            liquidity
+        );
+
+        (ethAmount, vTokenAmount) = address(vault) < address(WETH) ? (amount1, amount0) : (amount0, amount1);
     }
 
     /// @dev refreshes position to get updated fee growth

--- a/test/Assertions.t.sol
+++ b/test/Assertions.t.sol
@@ -3,10 +3,202 @@ pragma solidity ^0.8.23;
 
 import "./AlignmentVault.t.sol";
 
+import {Ownable} from "../lib/solady/src/auth/Ownable.sol";
+import {MockERC1155} from "../lib/solady/test/utils/mocks/MockERC1155.sol";
+
 contract AssertionsTest is AlignmentVaultTest {
-    /// @todo liquidity management reverts
-    /// @todo inventory management reverts
-    /// @todo aligned token management reverts
-    /// @todo misc token management reverts
-    /// @todo NFT receiver reverts
+
+    address notOwner = makeAddr('not owner');
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //              LIQUIDITY MANAGEMENT ASSERTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testRevert_LiquidityPositionCreate_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.liquidityPositionCreate({
+            ethAmount: 0,
+            vTokenAmount: 0,
+            tokenIds: none,
+            amounts: none,
+            tickLower: 0,
+            tickUpper: 0,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+    }
+
+    function testRevert_LiquidityPositionIncrease_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.liquidityPositionIncrease({
+            positionId: 0,
+            ethAmount: 0,
+            vTokenAmount: 0,
+            tokenIds: none,
+            amounts: none,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+    }
+
+    function testRevert_LiquidityPositionWithdraw_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.liquidityPositionWithdrawal({
+            positionId: 0,
+            tokenIds: none,
+            vTokenPremiumLimit: 0,
+            liquidity: 0,
+            amount0Min: 0,
+            amount1Min: 0
+        });
+    }
+
+    function testRevert_LiquidityPositionCollectFees_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.liquidityPositionCollectFees(deployer, none);
+    }
+
+    function testRevert_LiquidityPositionCollectAllFees_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.liquidityPositionCollectAllFees(deployer);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //              INVENTORY MANAGEMENT ASSERTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testRevert_InventoryPositionCreateNfts_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionCreateNfts(none, none);
+    }
+
+    function testRevert_InventoryPositionCreateVToken_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionCreateVToken(0);
+    }
+
+    function testRevert_InventoryPositionIncrease_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionIncrease(0 ,0);
+    }
+
+    function testRevert_InventoryPositionWithdraw_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionWithdrawal(0, 0, none, 0);
+    }
+
+    function testRevert_InventoryPositionCombine_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionCombine(0, none);
+    }
+
+    function testRevert_InventoryPositionCollectFees_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionCollectFees(deployer, none);
+    }
+
+    function testRevert_InventoryPositionCollectAllFees_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.inventoryPositionCollectAllFees(deployer);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //              ALIGNED MANAGEMENT ASSERTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testRevert_BuyNftsFromPool_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.buyNftsFromPool(0, none, 0, 0, 0);
+    }
+
+    function testRevert_MintVToken_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.mintVToken(none, none);
+    }
+
+    function testRevert_BuyVToken_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.buyVToken(0, 0, 0, 0);
+    }
+
+    function testRevert_BuyVTokenExact_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.buyVTokenExact(0, 0, 0, 0);
+    }
+
+    function testRevert_SellVToken_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.sellVToken(0, 0, 0, 0);
+    }
+
+    function testRevert_SellVTokenExact_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.sellVTokenExact(0, 0, 0, 0);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                  MISC MANAGEMENT ASSERTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testRevert_RescueERC20_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.rescueERC20(address(0), 0, address(0));
+    }
+
+    function testRevert_RescueERC721_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.rescueERC721(address(0), 0, address(0));
+    }
+
+    function testRevert_UnwrapEth_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.unwrapEth(0);
+    }
+
+    function testRevert_WrapEth_Ownable() public prank(notOwner) {
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        av.wrapEth(0);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                  RECEIVER ASSERTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testRevert_OnERC721Received_UnalignedNft_Unaligned() public {
+        IERC721 unaligned = IERC721(0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D);
+        vm.startPrank(unaligned.ownerOf(1));
+        vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector);
+        unaligned.safeTransferFrom(unaligned.ownerOf(1), address(av), 1);
+    }
+
+    function testRevert_OnERC721Received_UnalignedNft_UnalignedLiquidityPosition() public {
+        vm.startPrank(NPM.ownerOf(10));
+        vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector); 
+        NPM.safeTransferFrom(NPM.ownerOf(10), address(av), 10);
+    }
+
+    function testRevert_OnERC721Received_UnalignedNft_UnalignedInventoryPosition() public {
+        vm.startPrank(NFTX_INVENTORY_STAKING.ownerOf(10));  
+        vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector);
+        NFTX_INVENTORY_STAKING.safeTransferFrom(NFTX_INVENTORY_STAKING.ownerOf(10), address(av), 10);
+    }
+
+    function testRevert_OnERC1155Received_Unaligned() public prank(notOwner) {
+        MockERC1155 unaligned = new MockERC1155();
+        unaligned.mint(notOwner, 1, 1, '');
+        vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector); 
+        unaligned.safeTransferFrom(notOwner, address(av), 1, 1, '');
+    }
+
+    function testRevert_OnERC1155BatchReceived_Unaligned() public prank(notOwner) {
+        MockERC1155 unaligned = new MockERC1155();
+        unaligned.mint(notOwner, 1, 1, '');
+        uint256 [] memory ids = new uint256[](1);
+        uint256 [] memory amounts = new uint256[](1);
+        ids[0] = amounts[0] = 1;
+        vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector); 
+        unaligned.safeBatchTransferFrom(notOwner, address(av), ids, amounts, '');
+    }
+
 }

--- a/test/Assertions.t.sol
+++ b/test/Assertions.t.sol
@@ -146,9 +146,34 @@ contract AssertionsTest is AlignmentVaultTest {
         av.rescueERC20(address(0), 0, address(0));
     }
 
+    function testRevert_RescueERC20_ProhibitedWithdrawal_VToken() public prank(deployer) {
+        vm.expectRevert(IAlignmentVault.AV_ProhibitedWithdrawal.selector);
+        av.rescueERC20(address(vault), 0, deployer);
+    }
+
+    function testRevert_RescueERC20_ProhibitedWithdrawal_Weth() public prank(deployer) {
+        vm.expectRevert(IAlignmentVault.AV_ProhibitedWithdrawal.selector);
+        av.rescueERC20(address(WETH), 0, deployer);
+    }
+
     function testRevert_RescueERC721_Ownable() public prank(notOwner) {
         vm.expectRevert(Ownable.Unauthorized.selector);
         av.rescueERC721(address(0), 0, address(0));
+    }
+
+    function testRevert_RescueERC721_ProhibitedWithdrawal_AlignedNft() public prank(deployer) {
+        vm.expectRevert(IAlignmentVault.AV_ProhibitedWithdrawal.selector);
+        av.rescueERC721(MILADY, 0, deployer);
+    }
+
+    function testRevert_RescueERC721_ProhibitedWithdrawal_LiquidityPosition() public prank(deployer) {
+        vm.expectRevert(IAlignmentVault.AV_ProhibitedWithdrawal.selector);
+        av.rescueERC721(address(NPM), 0, deployer);
+    }
+
+    function testRevert_RescueERC721_ProhibitedWithdrawal_InventoryPosition() public prank(deployer) {
+        vm.expectRevert(IAlignmentVault.AV_ProhibitedWithdrawal.selector);
+        av.rescueERC721(address(NFTX_INVENTORY_STAKING), 0, deployer);
     }
 
     function testRevert_UnwrapEth_Ownable() public prank(notOwner) {
@@ -162,26 +187,29 @@ contract AssertionsTest is AlignmentVaultTest {
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
-    //                  RECEIVER ASSERTIONS
+    //                   RECEIVER ASSERTIONS
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
 
     function testRevert_OnERC721Received_UnalignedNft_Unaligned() public {
         IERC721 unaligned = IERC721(0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D);
-        vm.startPrank(unaligned.ownerOf(1));
+        address holder = unaligned.ownerOf(1);
+        vm.prank(holder);
         vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector);
-        unaligned.safeTransferFrom(unaligned.ownerOf(1), address(av), 1);
+        unaligned.safeTransferFrom(holder, address(av), 1);
     }
 
     function testRevert_OnERC721Received_UnalignedNft_UnalignedLiquidityPosition() public {
-        vm.startPrank(NPM.ownerOf(10));
+        address holder = NPM.ownerOf(10);
+        vm.prank(holder);
         vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector); 
-        NPM.safeTransferFrom(NPM.ownerOf(10), address(av), 10);
+        NPM.safeTransferFrom(holder, address(av), 10);
     }
 
     function testRevert_OnERC721Received_UnalignedNft_UnalignedInventoryPosition() public {
-        vm.startPrank(NFTX_INVENTORY_STAKING.ownerOf(10));  
+        address holder = NFTX_INVENTORY_STAKING.ownerOf(10);
+        vm.prank(holder);  
         vm.expectRevert(IAlignmentVault.AV_UnalignedNft.selector);
-        NFTX_INVENTORY_STAKING.safeTransferFrom(NFTX_INVENTORY_STAKING.ownerOf(10), address(av), 10);
+        NFTX_INVENTORY_STAKING.safeTransferFrom(holder, address(av), 10);
     }
 
     function testRevert_OnERC1155Received_Unaligned() public prank(notOwner) {

--- a/test/Assertions.t.sol
+++ b/test/Assertions.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.23;
+
+import "./AlignmentVault.t.sol";
+
+contract AssertionsTest is AlignmentVaultTest {
+    /// @todo liquidity management reverts
+    /// @todo inventory management reverts
+    /// @todo aligned token management reverts
+    /// @todo misc token management reverts
+    /// @todo NFT receiver reverts
+}

--- a/test/Initialization.t.sol
+++ b/test/Initialization.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.23;
+
+import "./AlignmentVault.t.sol";
+
+contract InitializationTest is AlignmentVaultTest {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                  INIT LOGIC TESTS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testTargetInitialize() public {
+        targetInitialize(MILADY, VAULT_ID);
+        assertEq(av.vaultId(), VAULT_ID);
+        assertEq(address(av.alignedNft()), MILADY);
+    }
+
+    function testLazyInitialize() public {
+        lazyInitialize(MILADY);
+        assertEq(av.vaultId(), VAULT_ID);
+        assertEq(address(av.alignedNft()), MILADY);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                      INIT LOGIC
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function lazyInitialize(address alignedNft_) public {
+        vm.startPrank(deployer);
+        bytes32 salt = keccak256('deterministic salt');
+        av = AlignmentVault(payable(avf.predictDeterministicAddress(salt)));
+        alignedNft = alignedNft_;
+        address[] memory vaults = NFTX_VAULT_FACTORY.vaultsForAsset(alignedNft_);
+        if (vaults.length == 0) revert IAlignmentVault.AV_NFTX_NoVaultsExist();
+
+        for (uint256 i; i < vaults.length; ++i) {
+            (uint256 mintFee, uint256 redeemFee, uint256 swapFee) = INFTXVaultV3(vaults[i]).vaultFees();
+            if (mintFee != NFTX_STANDARD_FEE || redeemFee != NFTX_STANDARD_FEE || swapFee != NFTX_STANDARD_FEE) {
+                continue;
+            } else if (INFTXVaultV3(vaults[i]).manager() != address(0)) {
+                continue;
+            } else {
+                vaultId = INFTXVaultV3(vaults[i]).vaultId();
+                vault = vaults[i];
+                break;
+            }
+        }
+
+        vm.expectEmit(address(av));
+        emit IAlignmentVault.AV_VaultInitialized(vault, vaultId);
+        //@audit what does it mean when vault id is zero?
+        //@response The initializer just wants it pointed at a standard 3/3/3 tax and finalized NFTX vault, if any exist
+        avf.deployDeterministic(deployer, alignedNft_, 0, salt);
+        vm.deal(address(av), FUNDING_AMOUNT);
+        setApprovals();
+        vm.stopPrank();
+    }
+
+    function targetInitialize(address alignedNft_, uint96 vaultId_) public {
+        bytes32 salt = keccak256('deterministic salt');
+        av = AlignmentVault(payable(avf.predictDeterministicAddress(salt)));
+        vault = NFTX_VAULT_FACTORY.vault(vaultId_);
+        vaultId = vaultId_;
+        alignedNft = alignedNft_;
+
+        vm.expectEmit(address(av));
+        emit IAlignmentVault.AV_VaultInitialized(vault, vaultId_);
+        avf.deployDeterministic(deployer, alignedNft_, vaultId_, salt);
+        vm.deal(address(av), FUNDING_AMOUNT);
+        setApprovals();
+    }
+}

--- a/test/InventoryPositions.t.sol
+++ b/test/InventoryPositions.t.sol
@@ -231,11 +231,11 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         amounts[0] = 1;
         amounts[1] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](1);
+        uint256[] memory positionIds = new uint256[](2);
 
         av.mintVToken(tokenIds, amounts);
         uint256 positionId = positionIds[0] = av.inventoryPositionCreateVToken(1 ether);
-        childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
+        positionIds[1] = childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -259,12 +259,12 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](1);
+        uint256[] memory positionIds = new uint256[](2);
 
         av.mintVToken(tokenIds, amounts);
         uint256 positionId = positionIds[0] = av.inventoryPositionCreateVToken(1 ether);
         tokenIds[0] = 420;
-        childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
+        positionIds[1] = childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -288,12 +288,12 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](1);
+        uint256[] memory positionIds = new uint256[](2);
 
         uint256 positionId = positionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
         tokenIds[0] = 420;
         av.mintVToken(tokenIds, amounts);
-        childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
+        positionIds[1] = childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -317,11 +317,11 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](1);
+        uint256[] memory positionIds = new uint256[](2);
 
         uint256 positionId = positionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
         tokenIds[0] = 420;
-        childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
+        positionIds[1] = childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));

--- a/test/InventoryPositions.t.sol
+++ b/test/InventoryPositions.t.sol
@@ -227,13 +227,11 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         amounts[0] = 1;
         amounts[1] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](2);
+        uint256[] memory positionIds = new uint256[](1);
 
         av.mintVToken(tokenIds, amounts);
-        uint256 positionId = av.inventoryPositionCreateVToken(1 ether);
-        positionIds[0] = positionId;
+        uint256 positionId = positionIds[0] = av.inventoryPositionCreateVToken(1 ether);
         childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
-        positionIds[1] = childPositionIds[0];
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -257,14 +255,12 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](2);
+        uint256[] memory positionIds = new uint256[](1);
 
         av.mintVToken(tokenIds, amounts);
-        uint256 positionId = av.inventoryPositionCreateVToken(1 ether);
-        positionIds[0] = positionId;
+        uint256 positionId = positionIds[0] = av.inventoryPositionCreateVToken(1 ether);
         tokenIds[0] = 420;
         childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
-        positionIds[1] = childPositionIds[0];
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -288,14 +284,12 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](2);
+        uint256[] memory positionIds = new uint256[](1);
 
-        uint256 positionId = av.inventoryPositionCreateNfts(tokenIds, amounts);
-        positionIds[0] = positionId;
+        uint256 positionId = positionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
         tokenIds[0] = 420;
         av.mintVToken(tokenIds, amounts);
         childPositionIds[0] = av.inventoryPositionCreateVToken(1 ether);
-        positionIds[1] = childPositionIds[0];
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));
@@ -319,13 +313,11 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1;
         uint256[] memory childPositionIds = new uint256[](1);
-        uint256[] memory positionIds = new uint256[](2);
+        uint256[] memory positionIds = new uint256[](1);
 
-        uint256 positionId = av.inventoryPositionCreateNfts(tokenIds, amounts);
-        positionIds[0] = positionId;
+        uint256 positionId = positionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
         tokenIds[0] = 420;
         childPositionIds[0] = av.inventoryPositionCreateNfts(tokenIds, amounts);
-        positionIds[1] = childPositionIds[0];
 
         vm.warp(block.timestamp + 3 days + 1);
         vm.expectEmit(address(av));

--- a/test/InventoryPositions.t.sol
+++ b/test/InventoryPositions.t.sol
@@ -11,6 +11,10 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         transferMilady(address(av), 420);
     }
 
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                  INVENTORY POSITION MANAGEMENT
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
     function testInventoryPositionCreateVToken() public prank(deployer) {
         uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = 69;
@@ -334,6 +338,8 @@ contract InventoryPositionsTest is AlignmentVaultTest {
         assertEq(vTokenShareBalance1, 0, "vTokenShareBalance doesn't match position");
         assertEq(av.getInventoryPositionIds(), positionIds, "inventory position IDs unaccounted for");
     }
+    
+    function testInventoryPositionCollectFees() public { /* @todo */ }
 
     function testInventoryPositionCollectAllFees() public {
         uint256[] memory tokenIds = new uint256[](1);

--- a/test/MiscTokenMgmt.t.sol
+++ b/test/MiscTokenMgmt.t.sol
@@ -22,6 +22,10 @@ contract MiscTokenMgmtTest is AlignmentVaultTest {
         deal(address(WETH), address(av), FUNDING_AMOUNT);
     }
 
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                  MISC TOKEN MANAGEMENT
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
     function testRescueERC20() public prank(deployer) {
         av.rescueERC20(address(erc20), 1 ether, deployer);
         assertEq(erc20.balanceOf(deployer), 1 ether, "ERC20 balance error");

--- a/test/MiscTokenMgmt.t.sol
+++ b/test/MiscTokenMgmt.t.sol
@@ -4,12 +4,10 @@ pragma solidity ^0.8.23;
 import "./AlignmentVault.t.sol";
 import {MockERC20} from "../lib/solady/test/utils/mocks/MockERC20.sol";
 import {MockERC721} from "../lib/solady/test/utils/mocks/MockERC721.sol";
-//import {MockERC1155} from "../lib/solady/test/utils/mocks/MockERC1155.sol";
 
 contract MiscTokenMgmtTest is AlignmentVaultTest {
     MockERC20 public erc20;
     MockERC721 public erc721;
-    //MockERC1155 public erc1155;
 
     function setUp() public override {
         super.setUp();
@@ -21,14 +19,7 @@ contract MiscTokenMgmtTest is AlignmentVaultTest {
         erc721.mint(address(this), 1);
         erc721.transferFrom(address(this), address(av), 1);
 
-        /*erc1155 = new MockERC1155();
-        erc1155.mint(address(this), 1, 1, "tokenURI_1");
-        erc1155.mint(address(this), 2, 2, "tokenURI_2");
-        erc1155.safeTransferFrom(address(this), address(av), 1, 1, "");
-        erc1155.safeTransferFrom(address(this), address(av), 2, 2, "");*/
-
-        WETH.deposit{value: 1 ether}();
-        WETH.transfer(address(av), 1 ether);
+        deal(address(WETH), address(av), FUNDING_AMOUNT);
     }
 
     function testRescueERC20() public prank(deployer) {
@@ -43,25 +34,13 @@ contract MiscTokenMgmtTest is AlignmentVaultTest {
         assertEq(erc721.ownerOf(1), deployer, "ERC721 ownerOf error");
     }
 
-    /*function testRescueERC1155() public prank(deployer) {
-        av.rescueERC1155(address(erc1155), 1, 1, deployer);
-        assertEq(erc1155.balanceOf(deployer, 1), 1, "ERC1155 balance error");
-    }
-
-    function testRescueERC1155Batch() public prank(deployer) {
-        uint256[] memory tokenIds = new uint256[](2);
-        tokenIds[0] = 1;
-        tokenIds[1] = 2;
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 1;
-        amounts[1] = 2;
-        av.rescueERC1155Batch(address(erc1155), tokenIds, amounts, deployer);
-        assertEq(erc1155.balanceOf(deployer, 1), 1, "ERC1155 balance error");
-        assertEq(erc1155.balanceOf(deployer, 2), 2, "ERC1155 balance error");
-    }*/
-
     function testUnwrapEth() public prank(deployer) {
         av.unwrapEth(1 ether);
         assertEq(address(av).balance, FUNDING_AMOUNT + 1 ether, "post-WETH unwrap ETH balance error");
+    }
+
+    function testWrapEth() public prank(deployer) {
+        av.wrapEth(1 ether);
+        assertEq(WETH.balanceOf(address(av)), FUNDING_AMOUNT + 1 ether, "post-WETH wrap WETH balance error");
     }
 }

--- a/test/ViewFunctions.t.sol
+++ b/test/ViewFunctions.t.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.23;
+
+import "./AlignmentVault.t.sol";
+
+contract ViewFunctionsTest is AlignmentVaultTest {
+
+    function setUp() public override {
+        super.setUp();
+        transferMilady(address(this), 69);
+        transferMilady(address(av), 333);
+        transferMilady(address(av), 420);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //                      VIEW FUNCTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    
+    /*function testGetInventoryPositionIds() public view {
+        av.getInventoryPositionIds();
+    }
+
+    function testGetSpecificInventoryPositionFees(uint256 posId) public view {
+        av.getSpecificInventoryPositionFees(posId);
+    }
+
+    function testGetTotalInventoryPositionFees() public view {
+        av.getTotalInventoryPositionFees();
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+    //             LIQUIDITY RELATED VIEW FUNCTIONS
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´*/
+
+    function testGetLiquidityPositionIds() public prank(deployer) {
+        deal(vault, address(av), 3 ether);
+        deal(address(WETH), address(av), 6 ether);
+
+        uint256[] memory ids = new uint256[](2);
+        
+        ids[0] = av.liquidityPositionCreate({
+            ethAmount: 3 ether,
+            vTokenAmount: 1.5 ether,
+            tokenIds: none,
+            amounts: none,
+            tickLower: type(int24).min,
+            tickUpper: type(int24).max,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+
+        ids[1] = av.liquidityPositionCreate({
+            ethAmount: 3 ether,
+            vTokenAmount: 1.5 ether,
+            tokenIds: none,
+            amounts: none,
+            tickLower: type(int24).min,
+            tickUpper: type(int24).max,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+
+        assertEq(av.getLiquidityPositionIds(), ids, "unexpected liquidity position ids");
+    }
+
+    function testGetSpecificLiquidityPositionFees() public prank(deployer) {
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 333;
+        tokenIds[1] = 420;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1;
+        amounts[1] = 1;
+
+        uint256 id = av.liquidityPositionCreate({
+            ethAmount: 3 ether,
+            vTokenAmount: 0,
+            tokenIds: tokenIds,
+            amounts: amounts,
+            tickLower: type(int24).min,
+            tickUpper: type(int24).max,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 1")))), 1 ether);
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 2")))), 1.5 ether);
+        _buyWethFromPool(address(uint160(uint256(keccak256("trader 3")))), 2 ether);
+
+        INonfungiblePositionManager.CollectParams memory params = INonfungiblePositionManager.CollectParams({
+            tokenId: id,
+            recipient: deployer,
+            amount0Max: 100, // returns no tokens to AV (putting 0 will cause a revert so we put a very small amount)
+            amount1Max: 100
+        });
+
+        uint256 balBeforeWeth = WETH.balanceOf(deployer);
+        uint256 balBeforeVToken = IERC20(vault).balanceOf(deployer);
+
+        _changePrank(address(av)); // cache position fees so far in manager
+        INonfungiblePositionManager(positionManager).collect(params);
+
+        assertEq(WETH.balanceOf(deployer) - balBeforeWeth, 100, "non-zero eth fees collected");
+        assertEq(IERC20(vault).balanceOf(deployer) - balBeforeVToken, 100, "non-zero eth fees collected");
+
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 4")))), 0.5 ether);
+        _buyWethFromPool(address(uint160(uint256(keccak256("trader 5")))), 1 ether);
+
+        (uint128 ethFeesExpected, uint256 vTokenFeesExpected) = av.getSpecificLiquidityPositionFees(id);
+
+        balBeforeWeth = WETH.balanceOf(deployer);
+        balBeforeVToken = IERC20(vault).balanceOf(deployer);
+
+        vm.expectEmit(true, false, false, true);
+        emit Collect(id, deployer, ethFeesExpected, vTokenFeesExpected);
+
+        _changePrank(deployer);
+        av.liquidityPositionCollectAllFees(deployer);
+
+        assertEq(WETH.balanceOf(deployer) - balBeforeWeth, ethFeesExpected, "unexpected eth fees collected");
+        assertEq(
+            IERC20(vault).balanceOf(deployer) - balBeforeVToken, vTokenFeesExpected, "unexpected vToken fees collected"
+        );
+    }
+
+    function testGetTotalLiquidityPositionFees() public prank(deployer) {
+        (int24 tickUpper, int24 tickLower) = _getUpperLowerTicks();
+
+        uint256 vTokenAmount = 2 ether;
+        uint256 ethAmount = 3 ether;
+
+        deal(vault, address(av), vTokenAmount * 2);
+
+        positionKey = keccak256(abi.encodePacked(positionManager, tickLower, tickUpper));
+
+        av.liquidityPositionCreate({
+            ethAmount: ethAmount,
+            vTokenAmount: vTokenAmount,
+            tokenIds: none,
+            amounts: none,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+
+        av.liquidityPositionCreate({
+            ethAmount: ethAmount,
+            vTokenAmount: vTokenAmount,
+            tokenIds: none,
+            amounts: none,
+            tickLower: type(int24).min,
+            tickUpper: type(int24).max,
+            sqrtPriceX96: 0,
+            ethMin: 0,
+            vTokenMin: 0
+        });
+
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 1")))), 1 ether);
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 2")))), 1.5 ether);
+        _buyWethFromPool(address(uint160(uint256(keccak256("trader 3")))), 2 ether);
+        _buyVTokenFromPool(address(uint160(uint256(keccak256("trader 4")))), 0.5 ether);
+
+        (uint128 ethFeesExpected, uint256 vTokenFeesExpected) = av.getTotalLiquidityPositionFees();
+
+        uint256 wethBalBefore = WETH.balanceOf(deployer);
+        uint256 vTokenBalBefore = IERC20(vault).balanceOf(deployer);
+
+        _changePrank(deployer);
+        av.liquidityPositionCollectAllFees(deployer);
+
+        assertEq(WETH.balanceOf(deployer) - wethBalBefore, ethFeesExpected, "unexpected eth fees collected");
+        assertEq(IERC20(vault).balanceOf(deployer) - vTokenBalBefore, vTokenFeesExpected, "unexpected vToken fees collected");
+    }
+
+}
+
+   


### PR DESCRIPTION
• cached length on loops
• asserted array lengths match in _countTokens
• removed fallback function
• added more checks in the ERC721 receiver & events
• added a check in inventory withdraw if the withdrawal includes NFTs, to revert if the share amount submitted in insufficient to withdraw the NFTs — also changed param to vTokenShares
• made inventory functions emit share delta instead of vTokenAmount
• added setters for position donations, included checks to ensure the position is valid
•  removed inventory position id from set on combining positions & adjusted test — not sure if you still want the empty positions inside?
• return values for token management 
• test updates
